### PR TITLE
Move mermaid diagrams into markdown files

### DIFF
--- a/doc/design/class_I.md
+++ b/doc/design/class_I.md
@@ -1,3 +1,4 @@
+```mermaid
 ---
 config:
   layout: fixed
@@ -41,3 +42,4 @@ flowchart TB
     style Class_I color:#D50000
 
 %% https://www.mermaidchart.com/app/projects/ffe65222-4209-4fef-bee5-883f569b7bd5/diagrams/54611d77-8be4-4e00-b812-9f7aeff2bae2/version/v0.1/edit
+```

--- a/doc/design/class_II.md
+++ b/doc/design/class_II.md
@@ -1,3 +1,4 @@
+```mermaid
 ---
 config:
   layout: fixed
@@ -51,3 +52,5 @@ flowchart TB
     style Class_II color:#D50000
 
 %% https://www.mermaidchart.com/app/projects/ffe65222-4209-4fef-bee5-883f569b7bd5/diagrams/cba40056-1d79-41fd-8bd6-e1feae93a5f1/version/v0.1/edit
+```
+

--- a/doc/design/class_III.md
+++ b/doc/design/class_III.md
@@ -1,3 +1,4 @@
+```mermaid
 ---
 config:
   layout: fixed
@@ -33,3 +34,4 @@ flowchart TB
     style Class_III color:#D50000
 
 %% https://www.mermaidchart.com/app/projects/ffe65222-4209-4fef-bee5-883f569b7bd5/diagrams/1ab5a820-77ac-4fb9-804d-fc36a56bf0e3/version/v0.1/edit
+```


### PR DESCRIPTION
This way we could see them right on github -- it renders them -- without copy pasting anywhere: those URLs seems to be "private" as not working for me.

Note: if those files are automagically synced somehow from the website, then I guess it would be reasonable to leave them as is, although would require "manual rendering"